### PR TITLE
ft: mount most of API domain to /api/...

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -6,6 +6,7 @@ from flask_sqlalchemy import SQLAlchemy
 db = SQLAlchemy()
 login_manager = LoginManager()
 bcrypt = Bcrypt()
+API_ROOT = "/api"
 
 from api.admin.APIAuth import APIAuth
 

--- a/api/app.py
+++ b/api/app.py
@@ -8,7 +8,7 @@ from sqlalchemy import URL
 # db must be initialized before importing models, that is what this import does
 from api import bcrypt, db, login_manager
 from api.admin import admin_bp
-from api.swagger.swagger_bp import swaggerui_blueprint
+from api.swagger.swagger_bp import swaggerui_bp
 from api.user import user_bp
 from api.user.author import model
 from api.user.author.model import Author
@@ -21,22 +21,24 @@ url = URL.create("", username="", password="", host="", database="")  # dialect+
 
 
 def create_app(testing_env=False):
-    react_build_dir = Path(__file__).parents[1] / "frontend" / "build"
-    app = Flask(__name__, static_folder=react_build_dir)
+    API_ROOT = "/api"
+    REACT_BUILD_DIR = Path(__file__).parents[1] / "frontend" / "build"
+
+    app = Flask(__name__, static_folder=REACT_BUILD_DIR)
 
     @app.route("/", defaults={"path": "index.html"})
     @app.route("/<path:path>")
     def serve(path):
-        if not (react_build_dir / path).exists():
+        if not (REACT_BUILD_DIR / path).exists():
             # for anything that we don't recognize, it's likely a frontend path, so we can serve index.html
             # react will route according the path accordingly
             path = "index.html"
         # otherwise, we should be serving a frontend resource here
         return send_from_directory(app.static_folder, path)
 
-    app.register_blueprint(user_bp, url_prefix="/authors")
-    app.register_blueprint(admin_bp, url_prefix="/admin")
-    app.register_blueprint(swaggerui_blueprint, url_prefix="/docs")
+    app.register_blueprint(user_bp, url_prefix=f"{API_ROOT}/authors")
+    app.register_blueprint(admin_bp, url_prefix=f"{API_ROOT}/admin")
+    app.register_blueprint(swaggerui_bp, url_prefix="/docs")
 
     app.config.from_object("api.config.Config")
 

--- a/api/app.py
+++ b/api/app.py
@@ -7,7 +7,7 @@ from flask_swagger import swagger
 from sqlalchemy import URL
 
 import api.user.followers.model
-from api import basic_auth, bcrypt, db, login_manager
+from api import API_ROOT, basic_auth, bcrypt, db, login_manager
 from api.admin.actions import actions_bp
 from api.admin.APIAuth import APIAuth
 from api.admin.APIConfig import APIConfig
@@ -25,7 +25,6 @@ url = URL.create("", username="", password="", host="", database="")  # dialect+
 
 
 def create_app(testing_env=False):
-    API_ROOT = "/api"
     REACT_BUILD_DIR = Path(__file__).parents[1] / "frontend" / "build"
 
     app = Flask(__name__, static_folder=REACT_BUILD_DIR)

--- a/api/app.py
+++ b/api/app.py
@@ -42,7 +42,7 @@ def create_app(testing_env=False):
 
     app.register_blueprint(user_bp, url_prefix=f"{API_ROOT}/authors")
     app.register_blueprint(nodes_bp, url_prefix=f"{API_ROOT}/nodes")
-    app.register_blueprint(admin_bp, url_prefix=f"{API_ROOT}/admin/action")
+    app.register_blueprint(actions_bp, url_prefix=f"{API_ROOT}/admin/action")
     app.register_blueprint(swaggerui_bp, url_prefix="/docs")
 
     app.config.from_object("api.config.Config")

--- a/api/app.py
+++ b/api/app.py
@@ -14,7 +14,7 @@ from api.admin.APIConfig import APIConfig
 from api.admin.model import AuthAdmin, Connection, ConnectionAdmin
 from api.admin.nodes import nodes_bp
 from api.admin.views import Logout, SettingsView
-from api.swagger.swagger_bp import swaggerui_blueprint
+from api.swagger.swagger_bp import swaggerui_bp
 from api.user.author.model import Author
 from api.user.comments.model import Comment
 from api.user.posts.model import Post

--- a/api/swagger/swagger_bp.py
+++ b/api/swagger/swagger_bp.py
@@ -5,6 +5,6 @@ SWAGGER_URL = "/docs"
 API_URL = "http://localhost:5000/spec"
 
 # Call factory function to create our blueprint
-swaggerui_blueprint = get_swaggerui_blueprint(
+swaggerui_bp = get_swaggerui_blueprint(
     SWAGGER_URL, API_URL  # Swagger UI static files will be mapped to '{SWAGGER_URL}/dist/'
 )

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from api import API_ROOT
 from api.app import create_app, db
 
 
@@ -8,13 +9,13 @@ class AuthActions(object):
         self._client = client
 
     def login(self, username="test", password="test"):
-        return self._client.post("/authors/login", json={"username": username, "password": password})
+        return self._client.post(f"{API_ROOT}/authors/login", json={"username": username, "password": password})
 
     def register(self, username="test", password="test"):
-        return self._client.post("/authors/register", json={"username": username, "password": password})
+        return self._client.post(f"{API_ROOT}/authors/register", json={"username": username, "password": password})
 
     def logout(self):
-        return self._client.post("/authors/logout")
+        return self._client.post(f"{API_ROOT}/authors/logout")
 
 
 @pytest.fixture

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1,5 +1,6 @@
 import pytest
 
+from api import API_ROOT
 from api.user.author import model
 
 
@@ -10,7 +11,7 @@ class TestAuth:
     """
 
     def test_register(self, client, app):
-        response = client.post("/authors/register", json={"username": "test", "password": "test"})
+        response = client.post(f"{API_ROOT}/authors/register", json={"username": "test", "password": "test"})
 
         # TODO Should be a redirect ????
         print(response.data)
@@ -33,7 +34,7 @@ class TestAuth:
         ),
     )
     def test_register_invalid_input(self, client, username, password, response_code):
-        response = client.post("/authors/register", json={"username": username, "password": password})
+        response = client.post(f"{API_ROOT}/authors/register", json={"username": username, "password": password})
 
         assert response.status_code == response_code
 
@@ -56,7 +57,7 @@ class TestAuth:
         auth.register()
         auth.login()
 
-        response = client.post("/authors/logout")
+        response = client.post(f"{API_ROOT}/authors/logout")
         assert response.status_code == 200
 
         """

--- a/frontend/src/services/author.js
+++ b/frontend/src/services/author.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+axios.defaults.baseURL = '/api';
 
 export const login = ({ username, password }) => {
   return axios.post('/authors/login', {

--- a/frontend/src/services/post.js
+++ b/frontend/src/services/post.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { getCurrentUserDetails } from './author';
+axios.defaults.baseURL = '/api';
 
 export function getPost(authorId, postId) {
   return axios.get(`/authors/${authorId}/posts/${postId}`);


### PR DESCRIPTION
allows use to use /author_id/post/post_id convention on the frontend without clobbering fe/be rounting