### PR TITLE
Clear image after submitting

### DIFF
--- a/frontend/src/components/Post/CreatePost.jsx
+++ b/frontend/src/components/Post/CreatePost.jsx
@@ -412,6 +412,7 @@ export default function CreatePost(props) {
               <Button
                 variant="success"
                 onClick={() => {
+                  setImage(); // Clear image when you submit
                   if (post.visibility === 'PRIVATE' && post.sendTo) {
                     createPrivatePost();
                     props.setUpdateFeed(true);


### PR DESCRIPTION
Image does not currently clear after you submit, disabling the user from submitting another image, this is a small fix for that