### PR TITLE
ft: much improved search

### DIFF
--- a/api/user/author/utils.py
+++ b/api/user/author/utils.py
@@ -1,0 +1,92 @@
+import asyncio
+import itertools
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Tuple
+
+import httpx
+import requests
+
+from api.admin.utils import auth_header_for_url
+
+logger = logging.getLogger(__name__)
+
+
+async def retrieve_authors_from_endpoints(endpoints: List[str]):
+    async with httpx.AsyncClient() as client:
+        tasks = [
+            *map(
+                lambda endpoint: asyncio.ensure_future(retrieve_authors_from_single_endpoint(client, endpoint)),
+                endpoints,
+            )
+        ]
+
+        return [*itertools.chain(*(await asyncio.gather(*tasks)))]
+
+
+async def retrieve_authors_from_single_endpoint(client: httpx.AsyncClient, endpoint: str) -> List[str]:
+    endpoint_headers = auth_header_for_url(endpoint)
+    logger.debug(f"/authors request: {endpoint=} {endpoint_headers=}")
+    try:
+        resp = await cache_request.get(client, endpoint, headers=endpoint_headers, follow_redirects=True, timeout=2)
+        if resp.status_code != 200:
+            logger.warning(f"non-200 resp from {endpoint=}: {resp.status_code=}")
+    except Exception as e:
+        logger.exception(f"failed to get {endpoint=}")
+        return []
+
+    try:
+        parsed = resp.json()
+    except Exception as e:
+        logger.warning(f"failed to decode resp: {resp.content.decode()=} {e}")
+        return []
+
+    return parsed.get("items", [])
+
+
+@dataclass
+class CachedResponse:
+    time: datetime
+    resp: Any
+
+
+class _RequestCacher:
+    """
+    requests doesn't cache responses, let's roll our own
+    ignore cache control headers
+    embrace client knowing what's best for it
+    (in reality, lots of endpoints don't have cache control implemented, and we hammer endpoints)
+    """
+
+    def __init__(self, cache_time_s: float):
+        self.responses: Dict[Tuple, CachedResponse] = {}
+        self.cache_timedelta = timedelta(seconds=cache_time_s)
+
+    async def _retrieve_from_cache_or_make_request(self, key):
+        refresh = True
+        if key in self.responses.keys():
+            cached_resp = self.responses[key]
+            # if now is past the amount of time we intended to cache for...
+            if datetime.now() < (cached_resp.time + self.cache_timedelta):
+                # no need to re-make the request, it's within the caching interval
+                refresh = False
+
+        if refresh:
+            # wow this is really uglier than i intended it to be. too late to go back idc
+            function, args, kwargs = key
+            cached_resp = self.responses[key] = CachedResponse(
+                datetime.now(), await function(*args, **json.loads(kwargs))
+            )
+
+        return cached_resp.resp
+
+    async def get(self, client: httpx.AsyncClient, *args, **kwargs):
+        # ok, I'm sorry. I never realized that this way of implementing caching would have been so cursed
+        # I never would have done it
+        key = (client.get, tuple(args), json.dumps(kwargs, sort_keys=True))
+        return await self._retrieve_from_cache_or_make_request(key)
+
+
+cache_request = _RequestCacher(cache_time_s=3)

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,13 +1,9 @@
 import enum
-import json
 import logging
 import random
 import re
 import uuid
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
-from string import ascii_lowercase
-from typing import Any, Dict, Tuple
 
 import requests
 from flask import request
@@ -99,46 +95,3 @@ def randomized_profile_img():
 
 def generate_object_ID() -> str:
     return str(uuid.uuid4())
-
-
-@dataclass
-class CachedResponse:
-    time: datetime
-    resp: Any
-
-
-class _RequestCacher:
-    """
-    requests doesn't cache responses, let's roll our own
-    ignore cache control headers
-    embrace client knowing what's best for it
-    (in reality, lots of endpoints don't have cache control implemented, and we hammer endpoints)
-    """
-
-    def __init__(self, cache_time_s: float):
-        self.responses: Dict[Tuple, CachedResponse] = {}
-        self.cache_timedelta = timedelta(seconds=cache_time_s)
-
-    def _retrieve_from_cache_or_make_request(self, key):
-        refresh = True
-        if key in self.responses.keys():
-            cached_resp = self.responses[key]
-            # if now is past the amount of time we intended to cache for...
-            if datetime.now() < (cached_resp.time + self.cache_timedelta):
-                # no need to re-make the request, it's within the caching interval
-                refresh = False
-
-        if refresh:
-            # wow this is really uglier than i intended it to be. too late to go back idc
-            cached_resp = self.responses[key] = CachedResponse(datetime.now(), key[0](*key[1], **json.loads(key[2])))
-
-        return cached_resp.resp
-
-    def get(self, *args, **kwargs):
-        # ok, I'm sorry. I never realized that this way of implementing caching would have been so cursed
-        # I never would have done it
-        key = (requests.get, tuple(args), json.dumps(kwargs, sort_keys=True))
-        return self._retrieve_from_cache_or_make_request(key)
-
-
-cache_request = _RequestCacher(cache_time_s=3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+httpx
 bcrypt==4.0.1
 certifi==2022.12.7
 cfgv==3.3.1


### PR DESCRIPTION
 - fairly strict timeout on endpoint replies
 - uses httpx for async requests so everything is done in parallel to be even faster
 - very fault tolerant
 - tested with unexpected responses and servers that never respond, works wonderfully
 
we also cache responses from the serverse for 3s ourselves, but i realize this is not necessary but it's solid enouhg I don't want to remove it
